### PR TITLE
feature(OSPO-8): add SBOM generation to GitHub release process

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/workflows/frontend-cd-pr-merge.yml
+++ b/.github/workflows/frontend-cd-pr-merge.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 name: Frontend CD on PR merge
 

--- a/.github/workflows/frontend-cd-push-to-ECR.yml
+++ b/.github/workflows/frontend-cd-push-to-ECR.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 name: Frontend CD - push to ECR
 

--- a/.github/workflows/frontend-ci-pr.yml
+++ b/.github/workflows/frontend-ci-pr.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 name: Frontend CI on PR
 

--- a/.github/workflows/gitflow-branch-name-check.yml
+++ b/.github/workflows/gitflow-branch-name-check.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 name: GitFlow - Enforce Branch Naming Convention
 

--- a/.github/workflows/gitflow-pr-target-check.yml
+++ b/.github/workflows/gitflow-pr-target-check.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 name: GitFlow - PR Target Check
 

--- a/.github/workflows/gitflow-prod-release.yml
+++ b/.github/workflows/gitflow-prod-release.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 name: Prod Release on Merge to Main
 

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 name: Release on New Release Branch
 

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # This workflow is triggered when a pull request is merged into the main branch
 # from a release/* branch. It extracts the release version from the source branch,


### PR DESCRIPTION
## Sensitive Credential Checks
- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [X] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Adds SBOM generation capabilities to the repository using GitHub Actions.

## Description
Introduces a new GitHub action, which on detecting a merge to main from a release/* branch performs the following steps:

1. Detects the source branch release version number
2. Generates an SPDX SBOM using the GitHub API
3. Creates a GitHub Release for the newly pushed release
4. Creates a GitHub Release for the newly pushed code and adds the generated SBOM file as a release asset.

## How Has This Been Tested?
This has been tested using a separate repository and confirmed as working.

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [X] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.