### PR TITLE
feat(dpav-994): added limits to user input for the data layers

### DIFF
--- a/api/src/data/layers.json
+++ b/api/src/data/layers.json
@@ -31,14 +31,7 @@
                     "active": true,
                     "id": "specialAreasOfConservation",
                     "name": "Special Areas of Conservation (SAC)",
-                    "attributes": [
-                        {
-                            "id": "minDistance",
-                            "description": "Set distance from SAC (km)",
-                            "defaultValue": 2,
-                            "valueType": "number"
-                        }
-                    ]
+                    "attributes": []
                 }
             ]
         },

--- a/api/src/services/asset-analysis.service.ts
+++ b/api/src/services/asset-analysis.service.ts
@@ -78,9 +78,9 @@ export class AssetAnalysisService {
     }
 
     /*
-     * A helper method to get the matched polygons based on the data layers and location provided. These polygons are order with the good layers (suitability rating of green) -> caution layers (suitability rating of amber) -> bad layers (suitability of red) -> exact bad layers (suitability rating of darkRed)
+     * A helper method to get the matched polygons based on the data layers and location provided. These polygons are ordered with the good layer (suitability rating of green) -> caution layers (suitability rating of amber) -> bad layers (suitability of red) -> exact bad layers (suitability rating of darkRed)
      *
-     * Good layers are comprised of polygons where the ws_spring1 property matches the provided user attribute range
+     * The good layer is a polygon with the dimensions of the provided location.
      * Caution layers are comprised of polygons where the minimum distance from a bad layer is 0.5 km.
      * Bad layers are comprised of polygons which envelope the polygons in the exact bad layer and account for the provided minimum distance attribute
      * Exact bad layers are comprised of polygons loaded from the specific data layers files.
@@ -98,8 +98,9 @@ export class AssetAnalysisService {
         };
         dataLayers.forEach((dataLayer) => {
             if (dataLayer.id === 'windSpeed') {
-                const minSpeed = dataLayer.attributes.find((attribute) => attribute.id === 'minSpeed')?.value || 4;
-                const maxSpeed = dataLayer.attributes.find((attribute) => attribute.id === 'maxSpeed')?.value || 7.5;
+                const minSpeed = dataLayer.attributes.filter((attribute) => attribute.value >= 0).find((attribute) => attribute.id === 'minSpeed')?.value || 4;
+                const maxSpeed =
+                    dataLayer.attributes.filter((attribute) => attribute.value >= 0).find((attribute) => attribute.id === 'maxSpeed')?.value || 7.5;
                 const windspeedLayer = this.dataProviderUtils.getWindspeedLayerData();
                 const windspeedBadLayerData: FeatureCollection<MultiPolygon> = {
                     type: 'FeatureCollection',
@@ -144,7 +145,8 @@ export class AssetAnalysisService {
                     )
                 );
             } else if (dataLayer.id == 'sitesOfSpecialScientificInterest') {
-                const minDistance: number = dataLayer.attributes.find((attribute) => attribute.id === 'minDistance')?.value || 1;
+                const minDistance: number =
+                    dataLayer.attributes.filter((attribute) => attribute.value >= 0).find((attribute) => attribute.id === 'minDistance')?.value || 1;
                 const sitesOfSpecialScientificInterestLayerData = this.dataProviderUtils.getSitesOfSpecialScientificInterestLayerData();
                 const sitesOfSpecialScientificInterestBufferedFeatures: Feature<Polygon>[] = [];
                 const sitesOfSpecialScientificInterestBuffered500MFeatures: Feature<Polygon>[] = [];
@@ -189,7 +191,8 @@ export class AssetAnalysisService {
                     )
                 );
             } else if (dataLayer.id === 'builtUpAreas') {
-                const minDistance: number = dataLayer.attributes.find((attribute) => attribute.id === 'minDistance')?.value || 1;
+                const minDistance: number =
+                    dataLayer.attributes.filter((attribute) => attribute.value >= 0).find((attribute) => attribute.id === 'minDistance')?.value || 1;
                 const builtupAreasLayerData = this.dataProviderUtils.getBuiltupAreasLayerData();
                 const builtupAreasBufferedFeatures: Feature<Polygon>[] = [];
                 const builtupAreasBuffered500MFeatures: Feature<Polygon>[] = [];
@@ -219,7 +222,8 @@ export class AssetAnalysisService {
                     this.getMatchedPolygonsForLayer(builtupAreasBuffer500MLayerData, location, 'amber', `Close to built up areas - <= ${minDistance + 0.5}km`)
                 );
             } else if (dataLayer.id == 'areasOfOutstandingNaturalBeauty') {
-                const minDistance: number = dataLayer.attributes.find((attribute) => attribute.id === 'minDistance')?.value || 1;
+                const minDistance: number =
+                    dataLayer.attributes.filter((attribute) => attribute.value >= 0).find((attribute) => attribute.id === 'minDistance')?.value || 1;
                 const areasOfNaturalBeautyLayerData = this.dataProviderUtils.getAreasOfNaturalBeautyLayerData();
                 const areasOfNaturalBeautyBufferedFeatures: Feature<Polygon>[] = [];
                 const areasOfNaturalBeautyBuffered500MFeatures: Feature<Polygon>[] = [];

--- a/frontend/src/components/layer-selection/LayerControlPanel.tsx
+++ b/frontend/src/components/layer-selection/LayerControlPanel.tsx
@@ -274,9 +274,15 @@ const LayerControlPanel = ({ mapRef, drawRef }: LayerControlPanelProps) => {
                                         <Typography variant="body2">{item.name}</Typography>
                                         <Checkbox id={checkboxId} checked={checkedLayers[item.name]} onChange={() => handleCheckboxChange(item.name)} />
                                     </label>
-                                    <IconButton size="small" onClick={() => openProps(item.name)}>
-                                        <MoreVertIcon fontSize="small" />
-                                    </IconButton>
+                                    {item.attributes.length > 0 ? (
+                                        <IconButton size="small" onClick={() => openProps(item.name)}>
+                                            <MoreVertIcon fontSize="small" />
+                                        </IconButton>
+                                    ) : (
+                                        <Box sx={{ fontSize: 'small', padding: '5px' }}>
+                                            <MoreVertIcon fontSize="small" sx={{ opacity: 0 }} />
+                                        </Box>
+                                    )}
                                 </Box>
                             );
                         })}
@@ -413,6 +419,7 @@ const LayerControlPanel = ({ mapRef, drawRef }: LayerControlPanelProps) => {
                                         key={attr.id}
                                         label={attr.description}
                                         type={attr.valueType === 'number' ? 'number' : 'text'}
+                                        InputProps={attr.valueType === 'number' ? { inputProps: { min: 0 } } : {}}
                                         select={(attr.options?.length ?? 0) > 0}
                                         fullWidth
                                         value={layerSettings[currentLayer][attr.description]}


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- SAC data layer cannot be manipulated by the user due to implementation limitation
- User is able to send -ve values through the UI to the analyze location endpoint.

## Description
<!--- Describe your changes in detail -->
- Removed the attributes for the SAC layer
- Removed the more verts icon button when no attributes are present for a layer
- Added a filter to the backend to use default values when negative values are passed through for the data layer attributes
- Added min to the input text field if it is of type number.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and runs correctly e2e.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/d0cbb37a-76cc-4089-969f-b8e4251fc750)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.