### PR TITLE
bugfix(MULTI-REQ) Round 3 of UI fixes

### DIFF
--- a/frontend/src/components/asset-marker/AssetControls.tsx
+++ b/frontend/src/components/asset-marker/AssetControls.tsx
@@ -5,7 +5,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import OpenWithIcon from '@mui/icons-material/OpenWith';
 import ControlIcon from '../../shared/control-icon/ControlIcon';
 
-const ControlsContainer = styled(Box)(({ theme }) => ({
+const ControlsContainer = styled(Box)(() => ({
     position: 'absolute',
     top: '-70px',
     left: '50%',
@@ -13,8 +13,6 @@ const ControlsContainer = styled(Box)(({ theme }) => ({
     display: 'flex',
     gap: '8px',
     padding: '3px',
-    borderRadius: '3px',
-    boxShadow: theme.shadows[2],
     zIndex: 1000,
 }));
 

--- a/frontend/src/components/layer-selection/LayerControlPanel.tsx
+++ b/frontend/src/components/layer-selection/LayerControlPanel.tsx
@@ -105,8 +105,8 @@ const LayerControlPanel = ({ mapRef, drawRef }: LayerControlPanelProps) => {
             setCheckedLayers(checks);
             setLayerSettings(defaults);
 
-            const firstCategory = Object.keys(transformed)[0];
-            if (firstCategory) setExpandedPanels([firstCategory]);
+            const allCategories = Object.keys(transformed);
+            setExpandedPanels(allCategories);
 
             setLayersLoaded(true);
         } catch (err) {

--- a/frontend/src/components/search/search-input/SearchInput.tsx
+++ b/frontend/src/components/search/search-input/SearchInput.tsx
@@ -9,11 +9,7 @@ const StyledTextField = styled(TextField)(({ theme }) => ({
         height: 48,
         minHeight: 48,
         padding: '0 16px',
-        '& fieldset': {
-            border: 'none',
-            margin: 0,
-            top: 0,
-        },
+        '& fieldset': { border: 'none', margin: 0, top: 0 },
         '&:hover fieldset': {
             outline: '4px solid',
             outlineColor: theme.palette.secondary.dark,
@@ -38,7 +34,6 @@ const SearchInput: React.FC<SearchInputProps> = ({ onSearchResultClick }) => {
 
     useEffect(() => {
         const controller = new AbortController();
-
         if (input.trim().length < MIN_INPUT_LENGTH) {
             setOptions([]);
             return;
@@ -61,10 +56,9 @@ const SearchInput: React.FC<SearchInputProps> = ({ onSearchResultClick }) => {
     }, [input]);
 
     const handleInputChange = useCallback((_e: unknown, value: string, reason: string) => {
-        if (reason !== 'reset') {
-            setInput(value);
-        }
+        if (reason !== 'reset') setInput(value);
     }, []);
+
     const handleChange = useCallback(
         (_e: unknown, value: SearchResponse | null) => {
             if (value && 'latitude' in value && 'longitude' in value) {
@@ -85,6 +79,9 @@ const SearchInput: React.FC<SearchInputProps> = ({ onSearchResultClick }) => {
             onChange={handleChange}
             clearIcon={<ClearIcon />}
             disableClearable={false}
+            noOptionsText={input.trim().length < MIN_INPUT_LENGTH ? '' : 'No options'}
+            open={input.trim().length >= MIN_INPUT_LENGTH}
+            filterOptions={(opts) => (input.trim().length >= MIN_INPUT_LENGTH ? opts : [])}
             slotProps={{
                 popper: {
                     modifiers: [{ name: 'offset', options: { offset: [0, 8] } }],
@@ -100,9 +97,7 @@ const SearchInput: React.FC<SearchInputProps> = ({ onSearchResultClick }) => {
                         input: {
                             'aria-label': 'Search by region',
                             ...params.InputProps,
-                            inputProps: {
-                                ...params.inputProps,
-                            },
+                            inputProps: { ...params.inputProps },
                             startAdornment: (
                                 <InputAdornment position="start">
                                     <SearchIcon />

--- a/frontend/src/shared/control-icon/ControlIcon.tsx
+++ b/frontend/src/shared/control-icon/ControlIcon.tsx
@@ -7,10 +7,10 @@ const StyledIconButton = styled(IconButton, { shouldForwardProp: (prop) => prop 
     color: isActive ? theme.palette.primary.contrastText : theme.palette.text.primary,
     height: '3rem',
     padding: 0,
-    width: '3rem',
     '&:hover': {
-        backgroundColor: isActive ? theme.palette.secondary.dark : theme.palette.action.hover,
+        backgroundColor: isActive ? theme.palette.secondary.dark : theme.palette.background.paper,
     },
+    width: '3rem',
     '& .MuiTouchRipple-root .MuiTouchRipple-child': {
         borderRadius: theme.shape.borderRadius,
     },

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -26,6 +26,11 @@ const theme = createTheme({
                 color: 'secondary',
             },
         },
+        MuiRadio: {
+            defaultProps: {
+                color: 'secondary',
+            },
+        },
     },
 });
 


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
DPAV-1190
DPAV-1191
DPAV-1192
DPAV-1195

## Description
 - Modified transparency of asset action buttons
 - Removed translucent box around asset action buttons
 - All layers expanded by default when layer panel loaded
 - Search bar no longer shows "No Options" when first clicked
 - Radio buttons modified to match main colour theme (light blue)

## How Has This Been Tested?
Tested and verified locally

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/e89d15ef-527d-436e-a3c8-a2fec22dac4b)
<img width="123" alt="image" src="https://github.com/user-attachments/assets/0141d6d9-d2b6-4943-a323-7ccc784afb5d" />
<img width="214" alt="image" src="https://github.com/user-attachments/assets/755aef0b-4603-48a4-99dd-f39477e16596" />
<img width="164" alt="image" src="https://github.com/user-attachments/assets/5b666805-033a-4885-9a14-d3f152d2cb92" />
<img width="140" alt="image" src="https://github.com/user-attachments/assets/ffad05f7-5f37-4e99-a2dd-e25ef5fadec5" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.