### PR TITLE
fix(NON-REQ): prevent asset marker loss on cancelled edit

### DIFF
--- a/frontend/src/components/asset-marker/AssetMarker.spec.tsx
+++ b/frontend/src/components/asset-marker/AssetMarker.spec.tsx
@@ -150,7 +150,6 @@ describe('AssetMarker', () => {
         const setPanelOpenMock = vi.fn();
         render(<AssetMarker longitude={lng} latitude={lat} setIsPanelOpen={setPanelOpenMock} />);
         fireEvent.click(screen.getByLabelText('Edit'));
-        expect(setMarkerPositionMock).toHaveBeenCalledWith(null);
         expect(setPanelOpenMock).toHaveBeenCalledWith(true);
     });
 });

--- a/frontend/src/components/asset-marker/AssetMarker.tsx
+++ b/frontend/src/components/asset-marker/AssetMarker.tsx
@@ -56,7 +56,6 @@ const AssetMarker: React.FC<AssetMarkerProps> = ({ longitude, latitude, onBoltCl
                                 if (setMarkerPosition) setMarkerPosition(null);
                             }}
                             onEditClick={() => {
-                                if (setMarkerPosition) setMarkerPosition(null);
                                 if (setIsPanelOpen) setIsPanelOpen(true);
                             }}
                             onMoveClick={() => {

--- a/frontend/src/components/search/add-asset/AddAssetButton.spec.tsx
+++ b/frontend/src/components/search/add-asset/AddAssetButton.spec.tsx
@@ -28,6 +28,7 @@ vi.mock('./AddAssetPanel', () => ({
 
 describe('AddAssetButton', () => {
     const setPlacingMock = vi.fn();
+    const setMarkerPositionMock = vi.fn();
 
     const TestAddAssetWrapper = () => {
         const [isPanelOpen, setIsPanelOpen] = useState(false);
@@ -41,6 +42,7 @@ describe('AddAssetButton', () => {
             selector({
                 setPlacing: setPlacingMock,
                 cachedHeatmap: { mock: 'data' },
+                setMarkerPosition: setMarkerPositionMock,
             })
         );
     });

--- a/frontend/src/components/search/add-asset/AddAssetButton.tsx
+++ b/frontend/src/components/search/add-asset/AddAssetButton.tsx
@@ -14,6 +14,7 @@ interface AddAssetButtonProps {
 
 const AddAssetButton = ({ isPanelOpen, setIsPanelOpen }: AddAssetButtonProps) => {
     const setPlacing = useMapStore((s) => s.setPlacing);
+    const setMarkerPosition = useMapStore((s) => s.setMarkerPosition);
     const markerPlaced = useMapStore((s) => s.markerPosition);
     const cachedHeatmap = useMapStore((s) => s.cachedHeatmap);
 
@@ -28,12 +29,13 @@ const AddAssetButton = ({ isPanelOpen, setIsPanelOpen }: AddAssetButtonProps) =>
     const handleAssetSelect = () => {
         setPlacing(true);
         setIsPanelOpen(false);
+        setMarkerPosition(null);
     };
 
     if (!cachedHeatmap) return null;
 
     // Hide add asset button if marker already placed
-    if (markerPlaced) return null;
+    if (markerPlaced && !isPanelOpen) return null;
 
     return (
         <StyledContainer>


### PR DESCRIPTION
## Sensitive Credential Checks
- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Prevents loss of asset marker position if a user clicks to edit, then cancels their choice.

## Description
Prevents loss of asset marker position if a user clicks to edit, then cancels their choice. Also hides add asset button when marker already placed.

## How Has This Been Tested?
Tested locally and through unit tests.

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [X] I have added tests to cover my changes.