### PR TITLE
fix(NON-REQ): prevent wind turbine stats from re-rolling on component refresh

### DIFF
--- a/frontend/src/components/grid-connect/GridConnectFooterPanel.tsx
+++ b/frontend/src/components/grid-connect/GridConnectFooterPanel.tsx
@@ -103,12 +103,12 @@ export default function GridConnectFooterPanel({ selectedSubstation }: GridConne
         return range.decimals !== undefined ? parseFloat(raw.toFixed(range.decimals)) : raw;
     };
 
-    const getStats = (substation: Substation): AssetStats => {
+    const stats = useMemo((): AssetStats => {
         return {
-            turbineId: `WT-${substation.id}`,
+            turbineId: `WT-${selectedSubstation.id}`,
             location: `${lat}, ${lng}`,
-            connectedSubstation: substation.name,
-            connectionDistance: substation.distanceFromTurbine,
+            connectedSubstation: selectedSubstation.name,
+            connectionDistance: selectedSubstation.distanceFromTurbine,
             outputMWh: getRandomInRange({ min: 5000, max: 25000, decimals: 0 }),
             outputMW: getRandomInRange({ min: 1.5, max: 8, decimals: 2 }),
             boostPercent: getRandomInRange({ min: 1, max: 20, decimals: 1 }),
@@ -116,11 +116,7 @@ export default function GridConnectFooterPanel({ selectedSubstation }: GridConne
             maxOutputMW: getRandomInRange({ min: 8, max: 12, decimals: 2 }),
             maxBoostPercent: getRandomInRange({ min: 20, max: 100, decimals: 1 }),
         };
-    };
-
-    const stats = useMemo(() => {
-        return getStats(selectedSubstation);
-    }, [selectedSubstation, getStats]);
+    }, [selectedSubstation]);
 
     return (
         <GridConnectFooterContainer>


### PR DESCRIPTION
## Sensitive Credential Checks
- [ ] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Due to method being memoised rather than outputs, stats for the turbine were being refreshed on each component refresh (e.g. when panning around the map).

## Description
<!--- Describe your changes in detail -->
Memoise the stats themselves rather than a function to generate them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Manually.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.