### PR TITLE
bugfix(MULTI-REQ): UI cleanup

### DIFF
--- a/frontend/src/components/grid-connect/select-substation/SelectSubstationButton.tsx
+++ b/frontend/src/components/grid-connect/select-substation/SelectSubstationButton.tsx
@@ -22,7 +22,7 @@ const SelectSubstationButton = () => {
         height: 48,
         minHeight: 48,
         fontWeight: 600,
-        fontSize: 20,
+        fontSize: 14,
         color: '#1a2233',
         bgcolor: 'transparent',
         border: 'none',

--- a/frontend/src/components/map-substations-list/SubstationsList.tsx
+++ b/frontend/src/components/map-substations-list/SubstationsList.tsx
@@ -64,7 +64,7 @@ const SubstationsList: React.FC<SubstationsListProps> = ({ items = [], onConfirm
             </List>
 
             <Box sx={{ p: 1, textAlign: 'center' }}>
-                <Button variant="contained" color="primary" onClick={handleConfirm} disabled={selectedIndex === null} size="medium">
+                <Button variant="contained" onClick={handleConfirm} disabled={selectedIndex === null} size="medium">
                     Confirm
                 </Button>
             </Box>

--- a/frontend/src/components/search/search-input/SearchInput.tsx
+++ b/frontend/src/components/search/search-input/SearchInput.tsx
@@ -78,6 +78,7 @@ const SearchInput: React.FC<SearchInputProps> = ({ onSearchResultClick }) => {
             clearIcon={<ClearIcon />}
             disableClearable={false}
             noOptionsText={input.trim().length < MIN_INPUT_LENGTH ? '' : 'No options'}
+            popupIcon={options.length > 0 ? undefined : null}
             filterOptions={(opts) => (input.trim().length >= MIN_INPUT_LENGTH ? opts : [])}
             slotProps={{
                 popper: {


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
DPAV-1204
DPAV-1256

## Description
 - Search dropdown not shown when no text entered
 - Search dropdown now collapses and expands search results when available
 - Confirm substation button in default style
 - (NON-REQ) Substation dropdown text reduced to display at same size as neighbouring button

## How Has This Been Tested?
Tested and verified locally

## Screenshots (if appropriate):
<img width="265" alt="image" src="https://github.com/user-attachments/assets/cc566f1d-3750-470f-b49b-2b8a068bf8fe" />
<img width="254" alt="image" src="https://github.com/user-attachments/assets/f35482bf-89a6-4560-a9bd-b50ce3e0d232" />
<img width="295" alt="image" src="https://github.com/user-attachments/assets/7626143b-684c-4c81-af82-8ad573855997" />
<img width="302" alt="image" src="https://github.com/user-attachments/assets/e0506d34-b359-4611-bd77-2fe353d32535" />
<img width="131" alt="image" src="https://github.com/user-attachments/assets/5f8a2819-6900-46a6-86b3-52b9916d0464" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.