### PR TITLE
feat(DPAV-1846) Privacy Notice back arrow - black

### DIFF
--- a/frontend/src/components/privacy-notice/PrivacyNotice.tsx
+++ b/frontend/src/components/privacy-notice/PrivacyNotice.tsx
@@ -1,4 +1,3 @@
-// components/privacy/PrivacyNotice.tsx
 import { Box, IconButton } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
@@ -31,7 +30,7 @@ export default function PrivacyNotice({ onClose }: Readonly<Props>) {
                     boxSizing: 'border-box',
                 }}
             >
-                <IconButton aria-label="Back" onClick={onClose} sx={{ mb: 0.5 }}>
+                <IconButton aria-label="Back" onClick={onClose} sx={{ mb: 0.5, color: 'primary.main' }}>
                     <ArrowBackIcon />
                 </IconButton>
 


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Makes the back arrow on the privacy notice black

## Description
As above

## How Has This Been Tested?
Verified locally

## Screenshots (if appropriate):
<img width="142" height="113" alt="image" src="https://github.com/user-attachments/assets/c89a3db0-94f7-4338-b604-44b8fa2e3039" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.